### PR TITLE
Fix typo in get_arg_parse()

### DIFF
--- a/explode/__init__.py
+++ b/explode/__init__.py
@@ -75,7 +75,7 @@ def get_arg_parser():
 
 def main():
 
-    args = get_arg_arpser().parse_args()
+    args = get_arg_parser().parse_args()
 
     setup_logging(args.debug)
 


### PR DESCRIPTION
This commit just fixes a typo in main() when calling get_arg_parser()
